### PR TITLE
fix DSP and CX4 build on Linux/MacOS filesystems

### DIFF
--- a/src/chip/CX4/CX4.vhd
+++ b/src/chip/CX4/CX4.vhd
@@ -1252,7 +1252,7 @@ begin
 		end if;
 	end process; 
 
-	DATA_ROM : entity work.spram generic map(10, 24, "src/chip/cx4/drom.mif")
+	DATA_ROM : entity work.spram generic map(10, 24, "src/chip/CX4/drom.mif")
 	port map(
 		clock		=> not CLK,
 		address	=> DATA_ROM_ADDR,

--- a/src/chip/DSP/DSPn.vhd
+++ b/src/chip/DSP/DSPn.vhd
@@ -427,7 +427,7 @@ begin
                     std_logic_vector(unsigned(PC) + ("1"&x"254")) when VER="011" else
                     std_logic_vector(unsigned(PC) + ("1"&x"954"));
 
-	PROG_ROM : entity work.spram_sz generic map(13, 24, 7018, "src/chip/dsp/dsp1b23410_p.mif")
+	PROG_ROM : entity work.spram_sz generic map(13, 24, 7018, "src/chip/DSP/dsp1b23410_p.mif")
 	port map(
 		clock		=> CLK,
 		address	=> PROG_ROM_ADDR,
@@ -435,7 +435,7 @@ begin
 	);
 
 	DATA_ROM_ADDR <= VER(2 downto 1) & (VER(0) or (RP(10) and VER(2))) & RP(9 downto 0);
-	DATA_ROM : entity work.spram_sz generic map(13, 16, 6144, "src/chip/dsp/dsp1b23410_d.mif")
+	DATA_ROM : entity work.spram_sz generic map(13, 16, 6144, "src/chip/DSP/dsp1b23410_d.mif")
 	port map(
 		clock		=> CLK,
 		address	=> DATA_ROM_ADDR,


### PR DESCRIPTION
the folders are referenced as lower case, but are upper case.
this is fine on case-insensitive filesystems(e.g. windows) but
breaks the RBF for DSP and CX4 games if built on linux and macos