### PR TITLE
Create option for emulator quirks

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -245,6 +245,7 @@ parameter CONF_STR = {
     "-;",
     "D1OI,SuperFX Speed,Normal,Turbo;",
     "D3O4,CPU Speed,Normal,Turbo;",
+    "OLM,SRAM Initialization,None,FF,00;",
     "-;",
     "R0,Reset;",
     "J1,A(SS Fire),B(SS Cursor),X(SS TurboSw),Y(SS Pause),LT(SS Cursor),RT(SS Fire),Select,Start;",
@@ -648,13 +649,16 @@ wire [19:0] BSRAM_ADDR;
 wire        BSRAM_CE_N;
 wire        BSRAM_WE_N;
 wire  [7:0] BSRAM_Q, BSRAM_D;
+wire  [7:0] BSRAM_INIT_VALUE;
+assign BSRAM_INIT_VALUE = (status[22] ? 8'h00 : (status[21] ? 8'hFF : ioctl_addr[7:0]));
+
 dpram_dif #(BSRAM_BITS,8,BSRAM_BITS-1,16) bsram 
 (
 	.clock(clk_sys),
 
 	//Thrash the BSRAM upon ROM loading
 	.address_a(cart_download ? ioctl_addr[BSRAM_BITS-1:0] : BSRAM_ADDR[BSRAM_BITS-1:0]),
-	.data_a(cart_download ? 8'hFF : BSRAM_D),
+	.data_a(cart_download ? BSRAM_INIT_VALUE : BSRAM_D),
 	.wren_a(cart_download ? ioctl_wr : ~BSRAM_CE_N & ~BSRAM_WE_N),
 	.q_a(BSRAM_Q),
 

--- a/SNES.sv
+++ b/SNES.sv
@@ -650,13 +650,12 @@ wire        BSRAM_CE_N;
 wire        BSRAM_WE_N;
 wire  [7:0] BSRAM_Q, BSRAM_D;
 wire  [7:0] BSRAM_INIT_VALUE;
-assign BSRAM_INIT_VALUE = (status[22] ? 8'h00 : (status[21] ? 8'hFF : ioctl_addr[7:0]));
-
+assign BSRAM_INIT_VALUE = (status[22] ? 8'h00 : (status[21] ? 8'hFF : ioctl_addr[7:0])); // Hardware behavior is random junk here, but emulators pre-fill with FF or 00
 dpram_dif #(BSRAM_BITS,8,BSRAM_BITS-1,16) bsram 
 (
 	.clock(clk_sys),
 
-	//Thrash the BSRAM upon ROM loading
+	//Thrash or initialize the BSRAM upon ROM loading
 	.address_a(cart_download ? ioctl_addr[BSRAM_BITS-1:0] : BSRAM_ADDR[BSRAM_BITS-1:0]),
 	.data_a(cart_download ? BSRAM_INIT_VALUE : BSRAM_D),
 	.wren_a(cart_download ? ioctl_wr : ~BSRAM_CE_N & ~BSRAM_WE_N),

--- a/SNES.sv
+++ b/SNES.sv
@@ -245,7 +245,7 @@ parameter CONF_STR = {
     "-;",
     "D1OI,SuperFX Speed,Normal,Turbo;",
     "D3O4,CPU Speed,Normal,Turbo;",
-    "OLM,RAM Initialization,None,FF,00;",
+    "OL,Emulator Quirks,Off,On;",
     "-;",
     "R0,Reset;",
     "J1,A(SS Fire),B(SS Cursor),X(SS TurboSw),Y(SS Pause),LT(SS Cursor),RT(SS Fire),Select,Start;",
@@ -285,7 +285,7 @@ wire [21:0] gamma_bus;
 
 // Hardware behavior is random junk for RAM initialization, but emulators pre-fill sections with FF or 00
 wire [7:0] RAM_INIT_BYTE_VALUE;
-assign RAM_INIT_BYTE_VALUE = (status[22] ? 8'h00 : (status[21] ? 8'hFF : ioctl_addr[7:0]));
+assign RAM_INIT_BYTE_VALUE = (status[21] ? 8'hFF : ioctl_addr[7:0]);
 
 hps_io #(.STRLEN($size(CONF_STR)>>3), .WIDE(1)) hps_io
 (


### PR DESCRIPTION
https://github.com/MiSTer-devel/SNES_MiSTer/commit/a7c06769ba75faf3c87c9721c5f6d9c53826186c and https://github.com/MiSTer-devel/SNES_MiSTer/commit/a257e5170aed1c0d685b809f9c505724db6426ba added behavior to mimic emulators so ROM hacks which don't initialize memory would work.  This adds an "Emulator Quirks" option for that, which can be reused if other emulator compatibility behaviors are added to the core.