### PR TITLE
MSU1 fix to remove status flag checks in the control register

### DIFF
--- a/rtl/chip/MSU1/MSU.sv
+++ b/rtl/chip/MSU1/MSU.sv
@@ -243,14 +243,8 @@ always @(posedge CLK or negedge RST_N) begin
                 end
                 // MSU Audio state control. (MSU_CONTROL).
                 16'h2007: begin
-                    if (!msu_status_audio_busy) begin
-                        //MSU_CONTROL <= DIN;
-                        msu_status_audio_repeat <= DIN[1];
-                        // We can only play/pause a track that has been set and mounted. Not on missing track either
-                        if (!msu_status_track_missing) begin
-                            msu_status_audio_playing_out <= DIN[0];
-                        end
-                    end
+                    msu_status_audio_repeat <= DIN[1];
+                    msu_status_audio_playing_out <= DIN[0];
                 end
                 default:;
             endcase


### PR DESCRIPTION
Remove the status checks on the control register. Those checks are not in the specification and may be causing some issues with hacks. The status bits are still required, but it is up to the hack to detect and act accordingly.