### PR TITLE
Remove GSU Fastrom option

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -293,7 +293,7 @@ wire reset = RESET | buttons[1] | status[0] | cart_download | spc_download | bk_
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -343,7 +343,6 @@ parameter CONF_STR = {
 	"P3,Hardware;",
 	"P3-;",
 	"D1P3OI,SuperFX Speed,Normal,Turbo;",
-	"D1P3oE,SuperFX FastROM,Yes,No;",
 	"D3P3O4,CPU Speed,Normal,Turbo;",
 	"P3OV,Sufami Cart swapping,No,Yes;",
 	"P3-;",
@@ -440,7 +439,6 @@ wire       GUN_BTN = status[27];
 wire [1:0] GUN_MODE = status[26:25];
 wire       GUN_TYPE = status[34];
 wire       GSU_TURBO = status[18];
-wire       GSU_FASTROM = ~status[46];
 wire       SUFAMI_SWAP = status[31];
 wire       BLEND = ~status[16];
 wire [1:0] mouse_mode = status[6:5];
@@ -570,7 +568,6 @@ main main
 
 	.GSU_ACTIVE(GSU_ACTIVE),
 	.GSU_TURBO(GSU_TURBO),
-	.GSU_FASTROM(GSU_FASTROM),
 	.SUFAMI_SWAP(SUFAMI_SWAP),
 	
 	.SYSCLKR_CE(SNES_SYSCLKR_CE),

--- a/rtl/chip/GSU/GSU.vhd
+++ b/rtl/chip/GSU/GSU.vhd
@@ -21,8 +21,7 @@ entity GSU is
 		SYSCLKF_CE	: in std_logic;
 		SYSCLKR_CE	: in std_logic;
 		
-		TURBO			: in std_logic;
-		FASTROM		: in std_logic;
+		TURBO		        : in std_logic;
 
 		IRQ_N			: out std_logic;
 		
@@ -393,7 +392,7 @@ begin
 	
 	
 	--CPU Core
-	CODE_IN_ROM <= '1' when PBR <= x"5F" or (PBR >= x"80" and FASTROM = '1') else '0';
+	CODE_IN_ROM <= '1' when PBR <= x"5F" else '0';
 	CODE_IN_RAM <= '1' when PBR(7 downto 1) = "0111000" else '0';
 	IN_CACHE <= '1' when CACHE_POS(15 downto 9) = "0000000" else '0';
 	VAL_CACHE <= CACHE_VALID(to_integer(CACHE_POS(8 downto 4)));

--- a/rtl/chip/GSU/GSUMap.vhd
+++ b/rtl/chip/GSU/GSUMap.vhd
@@ -49,8 +49,7 @@ entity GSUMap is
 		ROM_MASK		: in std_logic_vector(23 downto 0);
 		BSRAM_MASK	: in std_logic_vector(23 downto 0);
 
-		TURBO		   : in std_logic;
-		FASTROM   	: in std_logic
+		TURBO		   : in std_logic
 	);
 end GSUMap;
 
@@ -93,8 +92,7 @@ begin
 		RAM_WE_N		=> RAM_WE_N,
 		RAM_CE_N		=> BSRAM_CE_N,
 				
-		TURBO			=> TURBO,
-		FASTROM		=> FASTROM
+		TURBO			=> TURBO
 	);
 	
 	ROM_ADDR 	<= ("00" & ROM_A) and ROM_MASK(22 downto 0);

--- a/rtl/main.v
+++ b/rtl/main.v
@@ -52,7 +52,6 @@ module main (
 
 	output            GSU_ACTIVE,
 	input             GSU_TURBO,
-	input             GSU_FASTROM,
 	input             SUFAMI_SWAP,
 
 	input             BLEND,
@@ -538,8 +537,7 @@ GSUMap GSUMap
 	.rom_mask(ROM_MASK),
 	.bsram_mask(RAM_MASK),
 
-	.turbo(GSU_TURBO),
-	.fastrom(GSU_FASTROM)
+	.turbo(GSU_TURBO)
 );
 end else
 assign MAP_ACTIVE[2] = 0;


### PR DESCRIPTION
Not used anymore on Star Fox EX hack and never used on any other hacks. (check with [kandowontu](https://github.com/kandowontu))
It may be permit to retrieve some logics.

I have tested Star Fox EX v1.11.02a, Star Fox and Star Fox 2 and also Yoshi Island.

Thanks,