### PR TITLE
fix BSX issue on Welcome Screen with linux compilation

### DIFF
--- a/rtl/chip/BSX/BSX_BS.vhd
+++ b/rtl/chip/BSX/BSX_BS.vhd
@@ -102,7 +102,7 @@ begin
 	
 	STREAM1_DATA_ADDR <= std_logic_vector(STREAM1.OFFS);
 	STREAM2_DATA_ADDR <= std_logic_vector(STREAM2.OFFS);
-	CH_DATA : entity work.dpram generic map(10, 8, "rtl/chip/bsx/bsx121-124.mif")
+	CH_DATA : entity work.dpram generic map(10, 8, "rtl/chip/BSX/bsx121-124.mif")
 	port map(
 		clock			=> CLK,
 		address_a	=> STREAM1_DATA_ADDR,


### PR DESCRIPTION
The autobuild (unstable) or linux compilation of the core have issue on Satellaview contents, it freezes on this screen.

<img width="1410" height="1080" alt="20250914_170110-Excitebike - Bunbun Mario Battle - Stadium 1 (Japan) (6-29) (SoundLink)" src="https://github.com/user-attachments/assets/da6a0817-12a3-4c78-85f5-e249fdf2fb94" />

After checking the file BSX_BS.vhd (CH_DATA : entity work.dpram generic map(10, 8, "rtl/chip/**bsx**/bsx121-124.mif") it shows the mif file have not the real name of the directory.
The real directory is rtl/chip/**BSX**/
This change permits with linux compilation to fix freeze on welcome screen of Satellaview contents.

<img width="1410" height="1080" alt="20250914_172647-Chrono Trigger - Character Zukan (Japan)" src="https://github.com/user-attachments/assets/0e4cbdbb-9e15-437c-8bed-fcd375e3dc14" />

It should fixed also autobuild for unstable.

Thanks,