### PR TITLE
PPU: Accuracy changes for BG & Mode7 Force Blank

### DIFF
--- a/rtl/PPU_PKG.vhd
+++ b/rtl/PPU_PKG.vhd
@@ -67,9 +67,9 @@ package PPU_PKG is
 
 	constant BG_FETCH_START		: unsigned(8 downto 0) := "000000000"; 	--0 
 	constant BG_FETCH_END		: unsigned(8 downto 0) := "100001111"; 	--(256+16)-1=271
-	constant M7_FETCH_START		: unsigned(8 downto 0) := "000001111"; 	--15
-	constant M7_FETCH_END		: unsigned(8 downto 0) := "100001110"; 	--(15+256)-1=270
-	constant M7_XY_LATCH			: unsigned(8 downto 0) := "000001000"; 	--8
+	constant M7_FETCH_START		: unsigned(8 downto 0) := "000001110"; 	--14
+	constant M7_FETCH_END		: unsigned(8 downto 0) := "100001101"; 	--(14+256)-1=269
+	constant M7_XY_LATCH			: unsigned(8 downto 0) := "000000111"; 	--7
 	constant SPR_GET_PIX_START	: unsigned(8 downto 0) := "000010000"; 	--16 
 	constant SPR_GET_PIX_END	: unsigned(8 downto 0) := "100001111"; 	--(16+256)-1=271
 	constant BG_GET_PIX_START	: unsigned(8 downto 0) := "000010001"; 	--17
@@ -204,9 +204,9 @@ package body PPU_PKG is
 	end function;
 
 	function Mode7Clip(a: signed(13 downto 0)) return signed is
-		variable res: signed(15 downto 0); 
+		variable res: signed(10 downto 0); 
 	begin
-		res := (0 to 5 => a(13)) & a(9 downto 0);
+		res := a(13) & a(9 downto 0);
 		return res;
 	end function;
 


### PR DESCRIPTION
This behavior was confirmed with test roms.

MPY implemented as described in the FullSnes doc. Mode7 gets 2 multiplication results per pixel. Signed 16x11 multiplier (27 bits).

If Force Blank is enabled during the M7_TEMP_X/Y calculation then it uses the result of the general purpose M7AxM7B multiply. That means the following line will start at the wrong position.

BG fetching continues during Force Blank but Tile map data and pixels read from VRAM will read as $FF.

Force Blank can be disabled at any BG fetch cycle. Depending on the cycle where Force Blank is disabled a BG layer will read Tile $3FF or pixels as color $FF.