### PR TITLE
CX4: Adjust bus access timings to reduce excess slowdown on wireframes

### DIFF
--- a/rtl/chip/CX4/CX4.vhd
+++ b/rtl/chip/CX4/CX4.vhd
@@ -935,10 +935,10 @@ begin
 								EXT_BUS_ADDR <= MAR;
 								if IR(0) = '0' then
 									ROM_ACCESS <= '1';
-									BUS_ACCESS_CNT <= unsigned(WS1);
+									BUS_ACCESS_CNT <= unsigned(WS1) - 1;
 								else
 									SRAM_ACCESS <= '1';
-									BUS_ACCESS_CNT <= unsigned(WS2);
+									BUS_ACCESS_CNT <= unsigned(WS2) - 1;
 									SRAM_WR <= '0';
 								end if;
 							end if;
@@ -963,7 +963,7 @@ begin
 						MBR <= A(7 downto 0);
 					elsif IR(8) = '1' and IR(7 downto 0) = "00101111" then
 						SRAM_ACCESS <= '1';
-						BUS_ACCESS_CNT <= unsigned(WS2);
+						BUS_ACCESS_CNT <= unsigned(WS2) - 1;
 						SRAM_WR <= '1';
 					end if;
 				end if;


### PR DESCRIPTION
This change removes an extra cycle on bus accesses that was causing excess slowdown on wireframes. According to [ikari's tests](https://forums.nesdev.org/viewtopic.php?t=14647), bus access takes 1+WS cycles before the next instruction.
```
assume WS1 = 3

before
INST = I_MOV, BUS_ACCESS_CNT <= unsigned(WS1) = 3
BUS_ACCESS_CNT <= 2
BUS_ACCESS_CNT <= 1
BUS_ACCESS_CNT <= 0
BUS_ACCESS_CNT = 0, MBR <= BUS_DI;
next
cycles before read 2 + WS = 5, expected 4

now
INST = I_MOV, BUS_ACCESS_CNT <= unsigned(WS1) - 1 = 2
BUS_ACCESS_CNT <= 1
BUS_ACCESS_CNT <= 0
BUS_ACCESS_CNT = 0, MBR <= BUS_DI;
next
cycles before read 1 + WS = 4
```

[Here is a comparison](https://www.youtube.com/watch?v=U8r9QHSk9pc) of the Mega Man X2 opening sequence between original console+cart, this commit, and the latest unstable. Slowdown on wireframes is now very close to console, as shown by X's wireframe head in the opening. This change doesn't introduce any regressions on title screen lag or attract mode desync.