### PR TITLE
SA-1: Assert BWRAM_OE_N during BWRAM prefetch

### DIFF
--- a/rtl/chip/SA1/SA1.vhd
+++ b/rtl/chip/SA1/SA1.vhd
@@ -622,6 +622,7 @@ BWRAM_OE_N <= '0'									                        when ENABLE = '0' else
 				  '0'									                        when DMA_SRC_BWRAM_SEL = '1' and DMA_BWRAM_WAIT = '0' else 
 				  DMA_EN								                        when DMA_DST_BWRAM_SEL = '1' and DMA_BWRAM_WAIT = '0' else 
 				  P65_WR								                        when SA1_BWRAM_SEL = '1' and SA1_BWRAM_VALID = '1' else 
+				  '0'									                        when SA1_BWRAM_SEL = '1' and SA1_BWRAM_VALID = '0' else 
 				  '1';
 
 --IRAM


### PR DESCRIPTION
Accessing banks 60-6F of the SA-1's memory space performs a read-modify-write operation against BWRAM. However, the core did not assert the output-enable line during the read phase of this operation.

Previously, this had no effect because the top-level core ignored the output-enable signal. However, after #462, the outut-enable signal is now used (so that SNI can steal idle BSRAM cycles), causing this bug to affect the behavior of BWRAM bitmap write operations.

Resolves #478.