### PR TITLE
Set BSRAM_SNI_READY only when SNI access is requested

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -995,9 +995,9 @@ wire        BSRAM_CE_N;
 wire        BSRAM_OE_N, BSRAM_WE_N;
 wire  [7:0] BSRAM_Q, BSRAM_D;
 wire [19:0] BSRAM_SNI_ADDR;
-wire        BSRAM_SNI_WR;
+wire        BSRAM_SNI_RD, BSRAM_SNI_WR;
 wire [7:0]  BSRAM_SNI_D;
-wire        BSRAM_SNI_READY = BSRAM_CE_N | (BSRAM_OE_N & BSRAM_WE_N);
+wire        BSRAM_SNI_READY = (BSRAM_SNI_RD | BSRAM_SNI_WR) & (BSRAM_CE_N | (BSRAM_OE_N & BSRAM_WE_N));
 
 dpram_dif #(BSRAM_BITS,8,BSRAM_BITS-1,16) bsram 
 (
@@ -1150,6 +1150,7 @@ sni sni(
 
 	.bsram_addr(BSRAM_SNI_ADDR),
 	.bsram_q(BSRAM_Q),
+	.bsram_rd(BSRAM_SNI_RD),
 	.bsram_wr(BSRAM_SNI_WR),
 	.bsram_data(BSRAM_SNI_D),
 	.bsram_ready(BSRAM_SNI_READY),

--- a/SNES.sv
+++ b/SNES.sv
@@ -1006,7 +1006,7 @@ dpram_dif #(BSRAM_BITS,8,BSRAM_BITS-1,16) bsram
 	//Thrash the BSRAM upon ROM loading
 	.address_a(clearing_ram ? mem_fill_addr[BSRAM_BITS-1:0] : BSRAM_SNI_READY ? BSRAM_SNI_ADDR : BSRAM_ADDR[BSRAM_BITS-1:0]),
 	.data_a(clearing_ram ? 8'hFF : BSRAM_SNI_READY ? BSRAM_SNI_D : BSRAM_D),
-	.wren_a(clearing_ram ? mem_fill_we : BSRAM_SNI_READY ? BSRAM_SNI_WR : ~BSRAM_WE_N),
+	.wren_a(clearing_ram ? mem_fill_we : BSRAM_SNI_READY ? BSRAM_SNI_WR : ~BSRAM_CE_N & ~BSRAM_WE_N),
 	.q_a(BSRAM_Q),
 
 	.address_b({sd_lba[BSRAM_BITS-10:0],sd_buff_addr}),

--- a/rtl/sni.sv
+++ b/rtl/sni.sv
@@ -121,7 +121,7 @@ module sni(
 
 		{rd_req, wr_req} <= 2'b0;
 		tdata_i <= 1'b0;
-		{bsram_rd_, bsram_wr_} <= 1'b0;
+		{bsram_rd_, bsram_wr_} <= 2'b0;
 
 		if (reset) begin
 			addr <= 24'b0;

--- a/rtl/sni.sv
+++ b/rtl/sni.sv
@@ -16,6 +16,7 @@ module sni(
 
 	output wire[19:0]	bsram_addr,
 	input  wire[7:0]	bsram_q,
+	output wire			bsram_rd,
 	output wire			bsram_wr,
 	output wire[7:0]	bsram_data,
 	input  wire			bsram_ready,
@@ -72,7 +73,8 @@ module sni(
 	assign bsram_addr = addr[19:0];
 	assign bsram_data = inbuffer_rdata;
 	reg last_bsram_ready;
-	reg bsram_wr_;
+	reg bsram_rd_, bsram_wr_;
+	assign bsram_rd = bsram_rd_;
 	assign bsram_wr = bsram_wr_;
 
 	reg[7:0] len;
@@ -119,7 +121,7 @@ module sni(
 
 		{rd_req, wr_req} <= 2'b0;
 		tdata_i <= 1'b0;
-		bsram_wr_ <= 1'b0;
+		{bsram_rd_, bsram_wr_} <= 1'b0;
 
 		if (reset) begin
 			addr <= 24'b0;
@@ -231,6 +233,7 @@ module sni(
 						else tdata <= 8'b0;
 						tinprogress <= 1'b1;
 						tdata_i <= 1'b1;
+						bsram_rd_ <= 1'b0;
 
 						// Use blocking assignments so that the if statement below can issue another SDRAM read
 						// request immediately, allowing read requests to be pipelined with UART transmissionss.
@@ -241,6 +244,8 @@ module sni(
 					if (sdram_sel && !sdram_busy && len != 24'h0) begin
 						rd_req <= 1'b1;
 						sdram_busy <= 1'b1;
+					end else if (bsram_sel) begin
+						bsram_rd_ <= 1'b1;
 					end
 				end
 			end else if (state == STATE_WAITNMI) begin


### PR DESCRIPTION
When no one is accessing BSRAM, give the bus to the cartridge by default.

As requested by @paulb-nl in https://github.com/MiSTer-devel/SNES_MiSTer/issues/478#issuecomment-4592438430.

(SDRAM_SNI_READY already behaves like this.)