### PR TITLE
Savestates: force NMI to capture states on NMI-disabled sections

### DIFF
--- a/rtl/CPU.vhd
+++ b/rtl/CPU.vhd
@@ -34,6 +34,7 @@ entity SCPU is
 		VBLANK			: in std_logic;
 		
 		IRQ_N				: in std_logic;
+		SS_NMI_FORCE	: in std_logic := '0';
 		
 		JOY1_DI			: in std_logic_vector(1 downto 0);
 		JOY2_DI			: in std_logic_vector(1 downto 0);
@@ -622,7 +623,7 @@ begin
 				end if;
 			end if;
 			
-			P65_NMI_N <= not (NMI_FLAG and NMI_EN);
+			P65_NMI_N <= not ((NMI_FLAG and NMI_EN) or SS_NMI_FORCE);
 			P65_IRQ_N <= (not IRQ_FLAG) and IRQ_N; 
 		end if;
 	end process;

--- a/rtl/SNES.vhd
+++ b/rtl/SNES.vhd
@@ -98,6 +98,7 @@ entity SNES is
 
 		SS_ADDR     : in std_logic_vector(8 downto 0);
 		SS_BUSY     : in std_logic;
+		SS_NMI_FORCE : in std_logic := '0';
 		SS_REGS_SEL : in std_logic;
 		SS_SMP_SEL  : in std_logic;
 		SS_WR       : in std_logic;
@@ -227,7 +228,8 @@ begin
 		VBLANK		=> INT_VBLANK,
 		
 		IRQ_N			=> IRQ_N,
-		
+		SS_NMI_FORCE => SS_NMI_FORCE,
+
 		CA				=> INT_CA,
 		CPURD_N		=> INT_CPURD_N,
 		CPUWR_N		=> INT_CPUWR_N,

--- a/rtl/main.v
+++ b/rtl/main.v
@@ -266,6 +266,7 @@ SNES SNES
 	.ss_regs_sel(SS_DSP_REGS_SEL),
 	.ss_smp_sel(SS_SMP_SEL),
 	.ss_busy(SS_BUSY),
+	.ss_nmi_force(SS_NMI_FORCE),
 	.ss_wr(~PAWR_N),
 	.ss_di(SS_DO),
 	.ss_spc_do(SS_SPC_DI),
@@ -893,6 +894,7 @@ wire  [7:0] SS_DSPN_DI;
 wire  [7:0] SS_GSU_DI;
 wire        SS_DO_OVR;
 wire        SS_ROM_OVR;
+wire        SS_NMI_FORCE;
 wire        SS_ARAM_SEL, SS_DSP_REGS_SEL, SS_SMP_SEL;
 wire        SS_BSRAM_SEL;
 wire        SS_DSPN_REGS_SEL, SS_DSPN_RAM_SEL;
@@ -970,7 +972,8 @@ savestates ss
 
 	.ss_do_ovr(SS_DO_OVR),
 	.ss_rom_ovr(SS_ROM_OVR),
-	.ss_busy(SS_BUSY)
+	.ss_busy(SS_BUSY),
+	.ss_nmi_force(SS_NMI_FORCE)
 );
 end else begin
 	assign SS_DO = 0;
@@ -991,6 +994,7 @@ end else begin
 	assign SS_DO_OVR = 0;
 	assign SS_ROM_OVR = 0;
 	assign SS_BUSY = 0;
+	assign SS_NMI_FORCE = 0;
 end
 endgenerate
 

--- a/rtl/savestates.sv
+++ b/rtl/savestates.sv
@@ -69,7 +69,8 @@ module savestates
 
 	output            ss_do_ovr,
 	output            ss_rom_ovr,
-	output reg        ss_busy
+	output reg        ss_busy,
+	output reg        ss_nmi_force
 );
 
 reg cpurd_n_old, cpuwr_n_old;
@@ -155,6 +156,16 @@ reg [3:0] ddr_state;
 reg [7:0] ddr_data;
 reg load_ready;
 
+// Force an NMI when a request has been armed too long without a vector fetch.
+// Some game sections (title screens) run with NMI disabled and no IRQ, so no
+// hijack point ever appears. Terminal force_cnt[20] = 2^20 MCLK ticks ~48.8 ms
+// (21.48 MHz NTSC / 21.28 MHz PAL), matching the sibling nmi_cycle_cnt idiom.
+reg [20:0] force_cnt;
+wire arm_pending = (save_en | (load_en & load_ready)) & ~ss_busy; // request waiting for a hijack
+wire force_ready = force_cnt[20];
+// ss_nmi_force is registered so the CPU core sees a clean reg->OR->reg path on
+// its NMI input (both modules run on MCLK); the extra cycle is nothing vs the timer.
+
 wire ddr_busy = ddr_req != ddr_ack;
 
 localparam DDR_IDLE = 4'd0, LOAD_DATA = 4'd1, WRITE_DATA = 4'd2,
@@ -193,7 +204,16 @@ always @(posedge clk) begin
 		ss_ext_addr <= 0;
 		ss_ext_addr_inc <= 0;
 		ddr_state <= DDR_IDLE;
+		force_cnt <= 0;
+		ss_nmi_force <= 0;
 	end else begin
+		if (arm_pending)
+			force_cnt <= force_ready ? force_cnt : force_cnt + 1'b1;
+		else
+			force_cnt <= 0;
+
+		ss_nmi_force <= arm_pending & force_ready;
+
 		if (~(load_en | save_en)) begin
 			if (~save_old & save) begin
 				save_en <= 1;
@@ -208,7 +228,7 @@ always @(posedge clk) begin
 
 		if (cpurd_ce) begin
 			if (nmi_vect_l | (~ss_use_nmi & irq_vect_l)) begin // Prefer to use NMI
-				if (~ss_busy & (save_en | (load_en & load_ready))) begin
+				if (arm_pending) begin
 					ss_busy <= 1; // Override NMI/IRQ vector
 					if (save_en) begin
 						ss_count <= ss_count + 1'b1;


### PR DESCRIPTION
## Problem

The save state engine only enters by hijacking an S-CPU NMI or IRQ vector fetch (native-mode `$00FFEA` / `$00FFEE`). Sections that run with NMI disabled (NMITIMEN bit 7 clear) and no IRQ source never fetch a vector, so a save or load request can never trigger. Title screens polling for Start via auto-joypad read are the common case.

Worse, the latched request is uncancelable: it fires at the next vector fetch once gameplay re-enables NMI, capturing or restoring a random later moment instead of the screen the user asked for.

Affected games include those tracked in #484 (Earth Defense Force, Super Ninja Kid, Operation Logic Bomb). The current workaround is a per-game ROM byte-patch to force NMI enable, which is not a general fix.

## Change

Add a timer to the savestate engine (`rtl/savestates.sv`): when a request stays armed for ~48.8 ms (2^20 MCLK ticks, matching the sibling `nmi_cycle_cnt` idiom) without a hijack, assert a new `ss_nmi_force`. This ORs into `P65_NMI_N` in `rtl/CPU.vhd`, injecting one NMI regardless of NMITIMEN. The existing vector-fetch hijack then steals that NMI and runs the helper, so the game's own handler never executes.

- Force drops as soon as `ss_busy` rises; NMI edge detection keeps it single-shot (no storm, no re-fire after the helper's RTI).
- When no request is armed the OR term is a no-op, so existing timing is unchanged. Normal-latency saves fire on the natural vblank NMI (~16 ms) long before the timer, so it never asserts during normal play.
- The signal threads `savestates.sv -> main.v -> SNES.vhd -> CPU.vhd`, following the existing `SS_*` port style, with `:= '0'` defaults on the VHDL ports.

## Scope

Consoles in 6502 emulation mode (NMI vector `$FFFA`, not hijacked) stay out of scope; the helper is native mode only, and commercial games are in native mode wherever a save makes sense.

## Validation

Verilog testbench on `savestates.sv` (iverilog): `ss_nmi_force` rises after the timer on a quiet bus, the resulting `$00FFEA` fetch starts the walk, the force drops once `ss_busy` rises, and it stays low on the normal prompt-latency path (natural saves untouched).

Addresses #484.