### PR TITLE
Savestates: fix VRAM/CGRAM corruption from mid-frame HDMAEN restore (Killer Instinct)

### DIFF
--- a/rtl/CPU.vhd
+++ b/rtl/CPU.vhd
@@ -45,6 +45,8 @@ entity SCPU is
 
 		TURBO				: in std_logic;
 		
+		SS_BUSY			: in std_logic := '0';
+		
 		DBG_CPU_EN		: in std_logic
 	);
 end SCPU;
@@ -114,6 +116,7 @@ architecture rtl of SCPU is
 	signal VTIME : std_logic_vector(8 downto 0);
 	signal MDMAEN : std_logic_vector(7 downto 0);
 	signal HDMAEN : std_logic_vector(7 downto 0);
+	signal HDMAEN_PEND : std_logic_vector(7 downto 0);
 	signal MEMSEL : std_logic;
 	signal RDDIV, RDMPY : std_logic_vector(15 downto 0);
 
@@ -864,6 +867,7 @@ begin
 		if RST_N = '0' then
 			MDMAEN <= (others => '0');
 			HDMAEN <= (others => '0');
+			HDMAEN_PEND <= (others => '0');
 			
 			DMAP <= (others => (others => '1'));
 			BBAD <= (others => (others => '1'));
@@ -887,13 +891,24 @@ begin
 			DS <= DS_IDLE;
 			HDS <= HDS_IDLE;
 		elsif rising_edge(CLK) then
+			--before the write decode so a CPU write to $420C wins
+			if FALLING_VBLANK = '1' and HDMAEN_PEND /= x"00" and SS_BUSY = '0' then
+				HDMAEN <= HDMAEN_PEND;
+				HDMAEN_PEND <= (others => '0');
+			end if;
 			if P65_R_WN = '0' and IO_SEL = '1' and INT_CLKF_CE = '1' then
 				if P65_A(15 downto 8) = x"42" then
 					case P65_A(7 downto 0) is
 						when x"0B" =>
 							MDMAEN <= P65_DO;
 						when x"0C" =>
-							HDMAEN <= P65_DO;
+							--savestate restore waits for HDMA init to reload the tables
+							if SS_BUSY = '1' and P65_DO /= x"00" then
+								HDMAEN_PEND <= P65_DO;
+							else
+								HDMAEN <= P65_DO;
+								HDMAEN_PEND <= (others => '0');
+							end if;
 						when others => null;
 					end case;
 				elsif P65_A(15 downto 7) = x"43"&"0" then

--- a/rtl/SNES.vhd
+++ b/rtl/SNES.vhd
@@ -254,6 +254,7 @@ begin
 		SNI_JOY		=> SNI_JOY,
 
 		TURBO			=> TURBO,
+		SS_BUSY		=> SS_BUSY,
 		DBG_CPU_EN	=> DBG_CPU_EN
 	);
 


### PR DESCRIPTION
Fixes one of the issue classes in #484.

**Problem:** In Killer Instinct (USA) (Rev 1), both capturing and loading a save state corrupt VRAM/CGRAM: background tiles clip to solid random colors and the backdrop shifts color. The damage persists until the game rewrites the data (stage change or reload). Both directions hit the same bug because save and load exit through the shared helper epilogue.

**Cause:** The savestate helper disables HDMA while it walks memory and restores HDMAEN mid-frame on exit. HDMA channels then start on the next scanline with stale table state: A2A and NTRL are only reloaded by HDMA init at the end of vblank, so they still hold the position where HDMA stopped several frames earlier. Up to a full frame of transfers runs with garbage table data. With a channel targeting VRAM/CGRAM data or address ports, the damage sticks.

**Fix:** In SCPU, a nonzero write to $420C while SS_BUSY is set is latched and applied at the falling VBLANK edge, right before HDMA init reloads the channels. Normal operation is untouched: with SS_BUSY clear the write applies immediately as before, a CPU write to $420C overrides any pending latched value, and writing zero always disables immediately.

Fixing this in the helper firmware instead (moving the HDMAEN restore into vblank) is not workable: the epilogue timing is constrained by the RTI handoff back to the interrupted game code.

**Before/after** (same scene, before and immediately after capturing a state on MiSTer):

<img width="1462" height="1120" alt="20260714_020202-Killer Instinct (USA) (Rev 1)" src="https://github.com/user-attachments/assets/82dfe04f-0c18-4e36-91c8-763da3ea6c66" />
<img width="1462" height="1120" alt="20260714_020209-Killer Instinct (USA) (Rev 1)" src="https://github.com/user-attachments/assets/397c7729-6127-41e3-8d04-68adae4dd02f" />
