### PR TITLE
MSU1: Restore loop point on track resume

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -577,6 +577,8 @@ main main
 	.MSU_AUDIO_PLAYING(msu_audio_playing),
 	.MSU_AUDIO_SECTOR(msu_audio_sector),
 	.MSU_RESUME_SECTOR(msu_resume_sector),
+	.MSU_AUDIO_LOOP_INDEX(msu_audio_loop_index),
+	.MSU_RESUME_LOOP_INDEX(msu_resume_loop_index),
 	.MSU_DATA_ADDR(msu_data_addr),
 	.MSU_DATA(msu_data),
 	.MSU_DATA_ACK(msu_data_ack),
@@ -1296,6 +1298,8 @@ wire        msu_audio_req;
 wire        msu_audio_seek;
 wire [21:0] msu_audio_sector;
 wire [21:0] msu_resume_sector;
+wire [31:0] msu_audio_loop_index;
+wire [31:0] msu_resume_loop_index;
 
 wire [15:0] msu_l;
 wire [15:0] msu_r;
@@ -1325,6 +1329,8 @@ msu_audio msu_audio
 	.audio_req(msu_audio_req),
 	.audio_seek(msu_audio_seek),
 	.resume_sector(msu_resume_sector),
+	.audio_loop_index(msu_audio_loop_index),
+	.resume_loop_index(msu_resume_loop_index),
 
 	.audio_l(msu_l),
 	.audio_r(msu_r)

--- a/rtl/chip/MSU1/MSU.sv
+++ b/rtl/chip/MSU1/MSU.sv
@@ -28,6 +28,8 @@ module MSU
 	output reg        audio_resume,
 	input      [21:0] audio_sector,
 	output reg [21:0] resume_sector,
+	input      [31:0] audio_loop_index,
+	output reg [31:0] resume_loop_index,
 
 	// Data track read
 	output reg [31:0] data_addr,
@@ -131,6 +133,7 @@ always @(posedge CLK) begin
 					if (DIN[2] && !DIN[0]) begin
 						resume_track_num <= track_num;
 						resume_sector <= audio_sector;
+						resume_loop_index <= audio_loop_index;
 						resume_valid <= 1;
 					end
 				end

--- a/rtl/chip/MSU1/msu_audio.v
+++ b/rtl/chip/MSU1/msu_audio.v
@@ -26,8 +26,10 @@ module msu_audio
 	output reg        audio_seek,
 	output reg [21:0] audio_sector,
 	input      [21:0] resume_sector,
- 
-	output     [15:0] audio_l,	 
+	output     [31:0] audio_loop_index,
+	input      [31:0] resume_loop_index,
+
+	output     [15:0] audio_l,
 	output     [15:0] audio_r
 );
 
@@ -38,6 +40,7 @@ localparam PLAYING_CHECKS_STATE   = 3;
 localparam END_SECTOR_STATE       = 4;
 
 reg [31:0] loop_index;
+assign     audio_loop_index = loop_index;
 reg  [2:0] state;
 reg        partial_sector_state;
 reg        looping, resuming;
@@ -70,6 +73,7 @@ always @(posedge clk) begin
 					looping <= 0;
 					audio_req <= 0;
 					audio_sector <= resuming ? resume_sector : 22'd0;
+					if (resuming) loop_index <= resume_loop_index;
 					if (~track_processing & ctl_play) begin
 						audio_seek <= 1;
 						resuming <= 0;

--- a/rtl/main.v
+++ b/rtl/main.v
@@ -115,6 +115,8 @@ module main (
 	output            MSU_AUDIO_PLAYING,
 	input      [21:0] MSU_AUDIO_SECTOR,
 	output     [21:0] MSU_RESUME_SECTOR,
+	input      [31:0] MSU_AUDIO_LOOP_INDEX,
+	output     [31:0] MSU_RESUME_LOOP_INDEX,
 	output     [31:0] MSU_DATA_ADDR,
 	input       [7:0] MSU_DATA,
 	input             MSU_DATA_ACK,
@@ -321,6 +323,8 @@ MSU MSU
 	.audio_stop(MSU_AUDIO_STOP),
 	.audio_sector(MSU_AUDIO_SECTOR),
 	.resume_sector(MSU_RESUME_SECTOR),
+	.audio_loop_index(MSU_AUDIO_LOOP_INDEX),
+	.resume_loop_index(MSU_RESUME_LOOP_INDEX),
 
 	.volume(MSU_VOLUME)
 );


### PR DESCRIPTION
**AI Disclosure:** I used an LLM to review my code and to walk me through building the core using Quartus.  I did **not** use an LLM for anything else, including authoring this PR description.

**Problem:** This video created by a friend of mine contains a complete repro.  The visible symptom can be found at this timestamp:
https://youtu.be/aexDi8WS6b0?si=UlMwYT9tbpWljnSu&t=91

In this repro, the MSU track for the overworld theme loops incorrectly and plays the same ~2.7 seconds repeatedly.

**Cause:** 
1) In rtl/chip/MSU1/msu_audio.v, the sample position of a track's loop point is held in a single
register, `loop_index`, that is only ever refreshed one way:

```
// msu_audio.v
if (audio_sector == 0 && data_cnt == 1 && data_wr && audio_ack) loop_index <= data + 2;
```

This only happens when sector 0 (the file header) of whatever track is currently playing streams.  (So, when a track
starts from the very beginning.)

2) With MSU resume enabled: when a track is paused with the resume flag set, MSU.sv latches the current playback sector into `resume_sector`.  Later, if the same track is selected again, playback jumps straight to `resume_sector` instead of
starting over.  (This is the whole point of resume.)

3) Combining 1 and 2, we get our bug.  Overworld track plays normally from the start.  It gets its correct loop point
captured into `loop_index`.  Player enters a dungeon.  Game pauses the overworld track with resume=1, which saves
`resume_sector` for the overworld track.  Then the plays dungeon track starting from sector 0.  As discussed in 1) above,
this overwrites `loop_index` with the dungeon track's loop point.  Finally, player leaves the dungeon.  Game re-selects
the overworld track, which matches the resume request, so playback jumps to `resume_sector`.  The track isn't played
from sector 0, so we don't refresh or restore `loop_index`, so it's left holding the *dungeon* track's loop point. When the
overworld track reaches its end and loops, it jumps back to the dungeon's loop point instead.

**Worked example**:

The video above uses the "Super Guitar Bros. Volume 1" msu.  I inspected the headers of the pcm files for two tracks
that produced a bad loop in actual play.  The "resume to" track was the "Light world overworld" track, and the "resume
from" track was the "Tower of Hera dungeon" track.

* LW Overworld:
    * File size: 13,873,432 bytes -> 3,468,356 samples of audio -> 78.65s total length
    * Header loop point: `fe 08 23 00` -> 2,296,062 samples -> 52.06s
    * So it plays a ~52s intro, then loops the last ~26.6s

* Hera Dungeon:
    * File size: 22,703,500 bytes -> 5,675,873 samples -> 128.71s total length
    * Header loop point: `1b 0f 33 00` -> 3,346,203 samples -> 75.88s
    * Plays 75.88s of intro, then loops the last 52.83s.

When the dungeon's stale loop point gets applied to the overworld theme, you have this situation:

```
Overworld total length:   3,468,356 samples
Dungeon's loop point:     3,346,203 samples
                         -----------
Remaining after bad jump:   122,153 samples = 2.77 seconds
```

This ~2.77s loop is what we've observed

**Fix:**

I found this bug by examing how the current MSU resume functionality works and comparing it to the sd2snes/fxpak pro's
implementation of MSU resume, here: https://github.com/mrehkopf/sd2snes/pull/67/changes#diff-99f4c9b29ebf4f486201b853c11342aa5e55b36bccd7301a198e6a62bd0cb87d

The avoid this issue by *always* reading sector 0 of a track to refresh the loop point.

I decided that since we're already persisting the resume_sector, the cleanest change that changes
semantics the least would be to also persist the *loop point*.  This involved threading one new 32-bit value
through the same path audio_sector and resume_sector are already taking.

I am **not a firmware/embedded engineer**.  I touched Verilog very briefly in college and haven't worked with it since.
Please review my changes accordingly.

**Testing:**

I've built the core using my changes and myself and the creator of the video have tested the fix.  In
the video, he swaps over to my test core at this timestamp: https://youtu.be/aexDi8WS6b0?si=RN07dB33RskH2g0r&t=151