### PR TITLE
MSU1: Fix bugs in register writes

### DIFF
--- a/rtl/chip/MSU1/MSU.sv
+++ b/rtl/chip/MSU1/MSU.sv
@@ -92,10 +92,9 @@ always @(posedge CLK) begin
 
 		// Set/reset pulsed signals
 		data_req <= 0;
-		audio_resume <= 0;
 		if (audio_stop) status_audio_playing <= 0;
 
-		// Rising edge of data busy
+		// Rising edge of data ack
 		data_ack_old <= data_ack;
 		if (!data_ack_old && data_ack) begin
 			status_data_busy <= 0;
@@ -121,13 +120,16 @@ always @(posedge CLK) begin
 				5: begin
 					track_num <= {DIN, MSU_TRACK};
 					track_request <= 1;
+					status_audio_playing <= 0;
+					status_audio_repeat <= 0;
 					if (resume_valid && resume_track_num == {DIN, MSU_TRACK}) begin
 						audio_resume <= 1;
 						resume_valid <= 0;
 					end
+					else audio_resume <= 0;
 				end
 				6: volume <= DIN;
-				7: begin
+				7: if (!status_audio_busy && !status_track_missing) begin
 					status_audio_repeat <= DIN[1];
 					status_audio_playing <= DIN[0];
 					if (DIN[2] && !DIN[0]) begin

--- a/rtl/chip/MSU1/msu_audio.v
+++ b/rtl/chip/MSU1/msu_audio.v
@@ -43,7 +43,7 @@ reg [31:0] loop_index;
 assign     audio_loop_index = loop_index;
 reg  [2:0] state;
 reg        partial_sector_state;
-reg        looping, resuming;
+reg        looping;
 
 always @(posedge clk) begin
 	if (reset) begin
@@ -53,13 +53,11 @@ always @(posedge clk) begin
 		audio_seek <= 0;
 		fifo_wren <= 0;
 		audio_req <= 0;
-		resuming <= 0;
 	end
 	else begin
 
 		// Set/reset pulsed signals
 		ctl_stop <= 0;
-		if (ctl_resume) resuming <= 1;
 
 		// Loop sector handling - also need to take into account the 8 bytes for file header (msu1 and loop index = 8 bytes)
 		if (audio_sector == 0 && data_cnt == 1 && data_wr && audio_ack) loop_index <= data + 2;
@@ -72,11 +70,10 @@ always @(posedge clk) begin
 					fifo_wren <= 0;
 					looping <= 0;
 					audio_req <= 0;
-					audio_sector <= resuming ? resume_sector : 22'd0;
-					if (resuming) loop_index <= resume_loop_index;
+					audio_sector <= ctl_resume ? resume_sector : 22'd0;
+					if (ctl_resume) loop_index <= resume_loop_index;
 					if (~track_processing & ctl_play) begin
 						audio_seek <= 1;
-						resuming <= 0;
 						state <= WAITING_ACK_STATE;
 					end
 				end


### PR DESCRIPTION
TLDR: The [MSU programming guide](https://helmet.kafuka.org/msu1.htm) says that on a write to $2005 MSB track select, the current track is stopped. The core did stop the track but it did not clear the play flag, so if a game requests a new track without stopping the current track first (which is legal) the new track will play immediately after mounting without a play command, which is wrong. This is the root cause for an audio glitch I noticed in a cutscene with FF6 DancingMad.

Since byuu developed MSU for higan/bsnes, [emulator source code](https://github.com/ares-emulator/ares/blob/449b93716fb162632de2fd43bf2eba2064fa43f2/ares/sfc/coprocessor/msu1/msu1.cpp#L129) counts as a reference design because it is not reverse engineered. This PR is based on this source code and fixes more than I was looking for.