### PR TITLE
MSU1: Remove obsolete gate

### DIFF
--- a/rtl/chip/MSU1/msu_audio.v
+++ b/rtl/chip/MSU1/msu_audio.v
@@ -72,7 +72,7 @@ always @(posedge clk) begin
 					audio_req <= 0;
 					audio_sector <= ctl_resume ? resume_sector : 22'd0;
 					if (ctl_resume) loop_index <= resume_loop_index;
-					if (~track_processing & ctl_play) begin
+					if (ctl_play) begin
 						audio_seek <= 1;
 						state <= WAITING_ACK_STATE;
 					end


### PR DESCRIPTION
This is a minor cleanup I realized afterwards. The play flag is now cleared when requesting a track *and* the game can't set it anymore before the track is mounted, so this gate is now useless. I propose to remove it because it was hiding the issue that the play flag was high when it was not supposed to be.