### PR TITLE
MSU1: Cleanup more glue logic

### DIFF
--- a/SNES.sv
+++ b/SNES.sv
@@ -1318,7 +1318,7 @@ msu_audio msu_audio
 	.ctl_repeat(msu_audio_repeat),
 
 	.track_size(msu_audio_size),
-	.track_processing(msu_track_missing | msu_track_mounting | msu_track_request),
+	.track_processing(msu_track_mounting | msu_track_request),
 
 	.audio_download(msu_audio_download),
 	.audio_data(ioctl_dout),

--- a/SNES.sv
+++ b/SNES.sv
@@ -1318,7 +1318,7 @@ msu_audio msu_audio
 	.ctl_repeat(msu_audio_repeat),
 
 	.track_size(msu_audio_size),
-	.track_processing(msu_track_mounting | msu_track_request),
+	.track_processing(msu_track_request),
 
 	.audio_download(msu_audio_download),
 	.audio_data(ioctl_dout),


### PR DESCRIPTION
The play flag can't be set anymore if the track is missing. That will also prevent the state machine from taking off, so this can be cleaned up