### PR TITLE
MSU1: Keep the state machine idle after track has ended

### DIFF
--- a/rtl/chip/MSU1/msu_audio.v
+++ b/rtl/chip/MSU1/msu_audio.v
@@ -72,7 +72,7 @@ always @(posedge clk) begin
 					audio_req <= 0;
 					audio_sector <= ctl_resume ? resume_sector : 22'd0;
 					if (ctl_resume) loop_index <= resume_loop_index;
-					if (ctl_play) begin
+					if (ctl_play && !ctl_stop) begin
 						audio_seek <= 1;
 						state <= WAITING_ACK_STATE;
 					end


### PR DESCRIPTION
I apologize for the number of PRs but I keep running into things that are worth fixing. The issue is in the following state transition:

https://github.com/MiSTer-devel/SNES_MiSTer/blob/735e05f48ac1aa5d11db99e84eebb3fbb7360216/rtl/chip/MSU1/msu_audio.v#L136-L141

This is supposed to turn the state machine idle if a track has ended and repeat is off, but it will arrive in this state with both the play and stop flags high. They will both be cleared the next cycle, but the state machine has already taken off by then. I think adding a gate for the stop flag is the most elegant solution to this one cycle event and the state machine will idle down properly.