### PR TITLE
CPU: Fix HDMA disable mid line (Weaponlord)

### DIFF
--- a/rtl/CPU.vhd
+++ b/rtl/CPU.vhd
@@ -151,7 +151,6 @@ architecture rtl of SCPU is
 	signal DMA_ACTIVE : std_logic;
 	signal HDMA_CH_WORK, HDMA_CH_RUN, HDMA_CH_DO: std_logic_vector(7 downto 0);
 	signal HDMA_CH_EN: std_logic_vector(7 downto 0);
-	signal HDMA_CH_ACTIVE: std_logic_vector(7 downto 0);
 	signal HDMA_EN, HDMA_START, HDMA_INIT_START : std_logic;
 	signal DMA_CH_EN: std_logic_vector(7 downto 0);
 	signal DMA_TRANSFER, HDMA_TRANSFER, FETCH_SCANLINE_COUNTER, FETCH_IND_ADDR, HDMA_BUS_ACTIVE : std_logic;
@@ -857,7 +856,6 @@ begin
 
 	--DMA/HDMA
 	HDMA_CH_EN <= HDMAEN and HDMA_CH_RUN and HDMA_CH_DO;
-	HDMA_CH_ACTIVE <= HDMA_CH_WORK and HDMA_CH_RUN and HDMA_CH_DO;
 	HDMA_CH_LAST <= IsLastHDMACh(HDMA_CH_EN and HDMA_CH_WORK, DMA_CH);
 	HDMA_EN <= '1' when (HDMAEN and HDMA_CH_RUN) /= x"00" else '0';
 				
@@ -1180,7 +1178,7 @@ begin
 		end if;
 	end process;
 
-	DMA_CH_EN <= HDMA_CH_ACTIVE when HDMA_RUN = '1' else MDMAEN;
+	DMA_CH_EN <= (HDMA_CH_WORK and HDMA_CH_RUN and HDMA_CH_DO) when HDMA_RUN = '1' else MDMAEN;
 	DMA_CH <= GetDMACh(DMA_CH_EN);
 
 	process( RST_N, CLK )

--- a/rtl/CPU.vhd
+++ b/rtl/CPU.vhd
@@ -1178,7 +1178,7 @@ begin
 		end if;
 	end process;
 
-	DMA_CH_EN <= (HDMA_CH_WORK and HDMA_CH_RUN and HDMA_CH_DO) when HDMA_RUN = '1' else MDMAEN;
+	DMA_CH_EN <= HDMA_CH_WORK and HDMA_CH_RUN and HDMA_CH_DO when HDMA_RUN = '1' else MDMAEN;
 	DMA_CH <= GetDMACh(DMA_CH_EN);
 
 	process( RST_N, CLK )

--- a/rtl/CPU.vhd
+++ b/rtl/CPU.vhd
@@ -151,6 +151,7 @@ architecture rtl of SCPU is
 	signal DMA_ACTIVE : std_logic;
 	signal HDMA_CH_WORK, HDMA_CH_RUN, HDMA_CH_DO: std_logic_vector(7 downto 0);
 	signal HDMA_CH_EN: std_logic_vector(7 downto 0);
+	signal HDMA_CH_ACTIVE: std_logic_vector(7 downto 0);
 	signal HDMA_EN, HDMA_START, HDMA_INIT_START : std_logic;
 	signal DMA_CH_EN: std_logic_vector(7 downto 0);
 	signal DMA_TRANSFER, HDMA_TRANSFER, FETCH_SCANLINE_COUNTER, FETCH_IND_ADDR, HDMA_BUS_ACTIVE : std_logic;
@@ -856,6 +857,7 @@ begin
 
 	--DMA/HDMA
 	HDMA_CH_EN <= HDMAEN and HDMA_CH_RUN and HDMA_CH_DO;
+	HDMA_CH_ACTIVE <= HDMA_CH_WORK and HDMA_CH_RUN and HDMA_CH_DO;
 	HDMA_CH_LAST <= IsLastHDMACh(HDMA_CH_EN and HDMA_CH_WORK, DMA_CH);
 	HDMA_EN <= '1' when (HDMAEN and HDMA_CH_RUN) /= x"00" else '0';
 				
@@ -1178,7 +1180,7 @@ begin
 		end if;
 	end process;
 
-	DMA_CH_EN <= HDMA_CH_EN and HDMA_CH_WORK when HDMA_RUN = '1' else MDMAEN;
+	DMA_CH_EN <= HDMA_CH_ACTIVE when HDMA_RUN = '1' else MDMAEN;
 	DMA_CH <= GetDMACh(DMA_CH_EN);
 
 	process( RST_N, CLK )


### PR DESCRIPTION
I've studied this issue long enough to propose the following fix. The root cause is that the game disables HDMA early while HDMA is running. Pretty sure that the expected behavior here is that this goes into effect on the next line. This does happen but it also breaks the ongoing HDMA because this hot register that the game just cleared is being used as a control signal during ongoing HDMA, so that breaks if the game clears it early.

The solution is then to remove this hot flag from the logic in a running HDMA. This patch introduces a new signal to track if HDMA is ongoing, which runs on latched data that the game can't touch. Use that to finish the ongoing HDMA instead and an ongoing HDMA can't break anymore if the flag gets cleared mid flight.

Fixes https://github.com/MiSTer-devel/SNES_MiSTer/issues/486
Many thanks to @VitalArtifice for the report and @paulb-nl for the capture

Note: This file suffers from mixed line endings. It took a lot of effort to workaround this for a clean diff. I will probably submit a fix for that too because that is a regular thing working in this repo.